### PR TITLE
Dashboard sidebar and assign game fixes

### DIFF
--- a/app/assigned/page.tsx
+++ b/app/assigned/page.tsx
@@ -22,7 +22,7 @@ export default function Competitions() {
     const [showExpired, setShowExpired] = useState<boolean>(false)
 
     function convertToLink(game_code: string, game_board: 'dual' | 'single'): string {
-        return game_board === 'dual' ? `/game/classic/dual/${game_code}` : `/game/classic/single/${game_code}`
+        return game_board === 'dual' ? `/game/classic/dual/${game_code}` : `/game/classic/single/game_code=${game_code}`
     }
 
     useEffect(() => {

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -73,20 +73,6 @@ const Sidebar = () => {
                         Assigned Games
                     </Link>
 
-                    <Link href="/leaderboard" 
-                        className="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100 rounded-lg"
-                    >
-                        <FontAwesomeIcon icon={faTrophy} className="w-5 h-5 mr-3" />
-                        Leaderboard
-                    </Link>
-
-                    <Link href="/history" 
-                        className="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100 rounded-lg"
-                    >
-                        <FontAwesomeIcon icon={faHistory} className="w-5 h-5 mr-3" />
-                        History
-                    </Link>
-
                     <Link href="/profile" 
                         className="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100 rounded-lg"
                     >


### PR DESCRIPTION
For assign game, fixed the link for single mode to have ?game_code=

For sidebar, removed history and leaderboard as those are integrated in the main dashboard